### PR TITLE
Disable robots in the ITB

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Getting started
         $ cp ci/travis.yml.template .travis.yml
         $ cp ci/travis.env.template .travis.env
 
-    Follow the instructions in the comments of [the environment file](travis.template.env) to customize Travis-CI for the parent repostiry. Merge in any local customizations from your existing `.travis.yml` file to the template.
+    Follow the instructions in the comments of [the environment file](travis.env.template) to customize Travis-CI for the parent repostiry. Merge in any local customizations from your existing `.travis.yml` file to the template.
 
 See the [docs repository](https://github.com/opensciencegrid/docs/) for an example [.travis.yml](https://github.com/opensciencegrid/docs/blob/master/.travis.yml) and [.travis.env](https://github.com/opensciencegrid/docs/blob/master/.travis.yml).
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Getting started
 
 1. From the root directory of your parent repository, copy the template to your travis configuration:
 
-        $ cp ci/travis.template.yml .travis.yml
-        $ cp ci/travis.template.env .travis.env
+        $ cp ci/travis.yml.template .travis.yml
+        $ cp ci/travis.env.template .travis.env
 
     Follow the instructions in the comments of [the environment file](travis.template.env) to customize Travis-CI for the parent repostiry. Merge in any local customizations from your existing `.travis.yml` file to the template.
 

--- a/deploy
+++ b/deploy
@@ -19,14 +19,9 @@ elif [[ "${TRAVIS_BRANCH}" =~ itb\..* ]]; then
 
     # Change color of ITB nav bar
     sed -i 's/\(extra_css:\)/\1\n  - css\/itb.css/' mkdocs.yml
-    cat > docs/css/itb.css << EOF
-.wy-side-nav-search {
-background-color: #CC0000;
-}
-.wy-nav-top {
-background-color: #CC0000;
-}
-EOF
+    CSS_DIR='docs/css/'
+    mkdir -p $CSS_DIR
+    cp ci/itb.css $CSS_DIR
 elif [[ "${TRAVIS_BRANCH}" != "master" ]]; then
     echo "Github page deployment not performed for non-master, non-ITB branch"
     exit 0

--- a/deploy
+++ b/deploy
@@ -22,6 +22,11 @@ elif [[ "${TRAVIS_BRANCH}" =~ itb\..* ]]; then
     CSS_DIR='docs/css/'
     mkdir -p $CSS_DIR
     cp ci/itb.css $CSS_DIR
+
+    # Prevent site crawling; requires theme custom_dir set to osgthedocs
+    THEME_DIR='osgthedocs'
+    mkdir -p $THEME_DIR
+    cp ci/no-robots.html $THEME_DIR/main.html
 elif [[ "${TRAVIS_BRANCH}" != "master" ]]; then
     echo "Github page deployment not performed for non-master, non-ITB branch"
     exit 0

--- a/itb.css
+++ b/itb.css
@@ -1,0 +1,6 @@
+.wy-side-nav-search {
+background-color: #CC0000;
+}
+.wy-nav-top {
+background-color: #CC0000;
+}

--- a/no-robots.html
+++ b/no-robots.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{%- block site_meta %}
+  <meta name="robots" content="noindex, nofollow" />
+{{ super() }}
+{%- endblock %}


### PR DESCRIPTION
I've created [this branch](https://github.com/opensciencegrid/docs/tree/itb.no_robots), which [deployed](https://travis-ci.org/opensciencegrid/docs/builds/301655111) to [docs-itb](https://opensciencegrid.github.io/docs-itb/) and you can see the relevant [meta tag](https://developers.google.com/search/reference/robots_meta_tag#using-the-robots-meta-tag) in the source.

