### PR TITLE
Verify via mkdocs server

### DIFF
--- a/verify
+++ b/verify
@@ -1,9 +1,10 @@
-#!/bin/bash -xe
+#!/bin/bash -x
 
 PYTHONPATH=src/ mkdocs serve --verbose --strict &
-set +xe
 timeout 15 bash -c 'until cat > /dev/tcp/localhost/8000; do sleep 0.5; done' > /dev/null 2>&1
-set -xe
-[ $? -eq 0 ] || exit 1
 linkchecker --config=ci/linkchecker.config 'http://localhost:8000/'
-pkill mkdocs # cleanup after ourselves
+
+# cleanup after ourselves
+linkchecker_rc=$?
+pkill mkdocs
+exit $linkchecker_rc

--- a/verify
+++ b/verify
@@ -1,5 +1,9 @@
 #!/bin/bash -xe
 
-PYTHONPATH=src/ mkdocs build --verbose --strict
-sed -i "s/\/${TRAVIS_REPO_SLUG#*/}\///" site/404.html # workaround for https://github.com/mkdocs/mkdocs/issues/1317
-linkchecker --config=ci/linkchecker.config site/index.html
+PYTHONPATH=src/ mkdocs serve --verbose --strict &
+set +xe
+timeout 15 bash -c 'until cat > /dev/tcp/localhost/8000; do sleep 0.5; done' > /dev/null 2>&1
+set -xe
+[ $? -eq 0 ] || exit 1
+linkchecker --config=ci/linkchecker.config 'http://localhost:8000/'
+pkill mkdocs # cleanup after ourselves


### PR DESCRIPTION
This is closer to production than 'mkdocs build' and verifying
file:/// links. The alternative solution to a mkdocs server is to
deploy with a root-enabled Travis-CI image and building into `/<repo>`
but decided against that since root images dramatically increases CI
build start time

https://github.com/mkdocs/mkdocs/issues/1317#issuecomment-347992063