### PR TITLE
Ignore only https

### DIFF
--- a/linkchecker.config
+++ b/linkchecker.config
@@ -9,7 +9,8 @@ ignore=
     # https://github.com/squidfunk/mkdocs-material/commit/36ec35c2e47bf0bed8de75ca658cab2017c10d29
     fonts.gstatic.com$
     # certificate issues
-    ^https://chtc.wisc.edu
+    ^https://koji.chtc.wisc.edu
+    ^https://cobbler-widmir.chtc.wisc.edu
     ^https://twiki.org
     ^https://batlab.org
     ^https://hypernews.cern.ch/HyperNews/CMS/get/osg-tier3.html

--- a/linkchecker.config
+++ b/linkchecker.config
@@ -9,13 +9,13 @@ ignore=
     # https://github.com/squidfunk/mkdocs-material/commit/36ec35c2e47bf0bed8de75ca658cab2017c10d29
     fonts.gstatic.com$
     # certificate issues
-    chtc.wisc.edu
-    twiki.org
-    batlab.org
-    hypernews.cern.ch/HyperNews/CMS/get/osg-tier3.html
-    ggus.eu
-    goc.egi.eu
-    xsede.org
+    ^https://chtc.wisc.edu
+    ^https://twiki.org
+    ^https://batlab.org
+    ^https://hypernews.cern.ch/HyperNews/CMS/get/osg-tier3.html
+    ^https://ggus.eu
+    ^https://goc.egi.eu
+    ^https://xsede.org
     ^https://meshconfig.opensciencegrid.org
     ^https://psconfig.opensciencegrid.org
     ^https://psetf.opensciencegrid

--- a/linkchecker.config
+++ b/linkchecker.config
@@ -16,7 +16,7 @@ ignore=
     ^https://hypernews.cern.ch/HyperNews/CMS/get/osg-tier3.html
     ^https://ggus.eu
     ^https://goc.egi.eu
-    ^https://xsede.org
+    ^https://portal.xsede.org
     ^https://meshconfig.opensciencegrid.org
     ^https://psconfig.opensciencegrid.org
     ^https://psetf.opensciencegrid


### PR DESCRIPTION
Tested with all mkdocs repos that had xsede links. With these changes, the linkchecker caught that xsede.org/osg-user-guide no longer exists (referenced by the operations repository)