### PR TITLE
Add 10min timeout for linkchecker

### DIFF
--- a/verify
+++ b/verify
@@ -2,7 +2,7 @@
 
 PYTHONPATH=src/ mkdocs serve --verbose --strict &
 timeout 30 bash -c 'until (echo > /dev/tcp/localhost/8000); do sleep 0.5; done' > /dev/null 2>&1
-linkchecker --config=ci/linkchecker.config 'http://localhost:8000/'
+timeout 600 bash -c 'linkchecker --config=ci/linkchecker.config http://localhost:8000/'
 
 # cleanup after ourselves
 linkchecker_rc=$?


### PR DESCRIPTION
In case linkchecker hangs. Using the timeout command because the
maxrunseconds linkchecker config option doesn't seem to work