### PR TITLE
Exclude registry.cilogon.org/registry from linkchecker

### DIFF
--- a/linkchecker.config
+++ b/linkchecker.config
@@ -30,3 +30,5 @@ ignore=
     ^http://itb-ce1.chtc.wisc.edu
     # windmill theme contains broken search links
     ^http://localhost:8000/search.html$
+    # 401 unauthorized
+    ^https://registry.cilogon.org/registry


### PR DESCRIPTION
It always gives a 401 unauthorized (probably because linkchecker can't do oauth)