### PR TITLE
New mkdocs

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,5 +1,5 @@
-Markdown==2.6.11  # Backversioned due to https://github.com/Python-Markdown/markdown/issues/725
-pymdown-extensions==5.0  # The latest versions requires Markdown>=3.0.1
+Markdown<3.2  # 3.2+ requires python 3
+pymdown-extensions<6.3  # 6.3+ requires Markdown 3.2
 mkdocs==0.17.5
 linkchecker; python_version < '3.0'
 requests==2.9.2 # https://github.com/wummel/linkchecker/issues/649

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -3,5 +3,5 @@ pymdown-extensions<6.3  # 6.3+ requires Markdown 3.2
 mkdocs; python_version < '3.0'
 linkchecker; python_version < '3.0'
 requests==2.9.2 # https://github.com/wummel/linkchecker/issues/649
-mkdocs-material==2.9.4
+mkdocs-material<4 # 4.0+ need mkdocs-material-extensions, which aren't in python 2
 mkdocs-windmill==0.1.6

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,6 +1,6 @@
 Markdown<3.2  # 3.2+ requires python 3
 pymdown-extensions<6.3  # 6.3+ requires Markdown 3.2
-mkdocs==0.17.5
+mkdocs; python_version < '3.0'
 linkchecker; python_version < '3.0'
 requests==2.9.2 # https://github.com/wummel/linkchecker/issues/649
 mkdocs-material==2.9.4


### PR DESCRIPTION
New version of mkdocs and some other dependencies.

Some caveats:
- mkdocs will print out the name of every markdown file it finds that is not listed in mkdocs.yml. This can get noisy, especially if we have several years worth of old unindexed weekly meeting notes...
- You must edit mkdocs.yml and rename `pages` to `nav`, or mkdocs will throw a warning (which turns into an error since the CI uses `--strict`)

(SOFTWARE-4141)